### PR TITLE
why is master called main?

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -11,7 +11,7 @@ on:
     types: [created]
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   update:


### PR DESCRIPTION
I see:
https://www.zdnet.com/article/github-to-replace-master-with-main-starting-next-month/