### PR TITLE
Revert "Bump coverage from 5.5 to 6.1.2 in /extra_requirements"

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -10,7 +10,7 @@ datashader==0.13.0
 dill==0.3.4                                     # Strax dependency
 coveralls==3.3.1
 commentjson==0.9.0
-coverage==6.1.2
+coverage==5.5
 dask==2021.11.1
 flake8==4.0.1
 hypothesis==6.21.1


### PR DESCRIPTION
Reverts XENONnT/pema#107