### PR TITLE
Track nestpy 1.5.0

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install requirements for tests and latest strax
         run: |
+          pip install git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0 
           pip install -r extra_requirements/requirements-tests.txt
           python setup.py develop
       # Secrets and required files

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install requirements for tests and latest strax
         run: |
-          pip install git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0 
+          pip install git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0
           pip install -r extra_requirements/requirements-tests.txt
           python setup.py develop
       # Secrets and required files

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -16,8 +16,9 @@ flake8==4.0.1
 hypothesis==6.21.1
 matplotlib==3.5.1
 multihist==0.6.5
-nestpy==1.5.0; python_version<="3.9"
-git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0; python_version=="3.10"
+# nestpy==1.5.0; python_version<="3.9"
+# git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0; python_version=="3.10"
+git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -17,8 +17,7 @@ hypothesis==6.21.1
 matplotlib==3.5.1
 multihist==0.6.5
 # nestpy==1.5.0; python_version<="3.9"
-# git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0; python_version=="3.10"
-git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0
+# git+https://github.com/NESTCollaboration/nestpy.git; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -17,7 +17,7 @@ hypothesis==6.21.1
 matplotlib==3.5.1
 multihist==0.6.5
 nestpy==1.5.0; python_version<="3.9"
-git+https://github.com/NESTCollaboration/nestpy.git@v1.0.6; python_version=="3.10"
+git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -17,7 +17,7 @@ hypothesis==6.21.1
 matplotlib==3.5.1
 multihist==0.6.5
 nestpy==1.5.0; python_version<="3.9"
-git+https://github.com/NESTCollaboration/nestpy/.git@v1.5.0; python_version=="3.10"
+git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -17,7 +17,7 @@ hypothesis==6.21.1
 matplotlib==3.5.1
 multihist==0.6.5
 nestpy==1.5.0; python_version<="3.9"
-git+https://github.com/NESTCollaboration/nestpy.git@1.5.0; python_version=="3.10"
+git+https://github.com/NESTCollaboration/nestpy.git; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -17,7 +17,7 @@ hypothesis==6.21.1
 matplotlib==3.5.1
 multihist==0.6.5
 nestpy==1.5.0; python_version<="3.9"
-git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0; python_version=="3.10"
+git+https://github.com/NESTCollaboration/nestpy.git@1.5.0; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -17,7 +17,7 @@ hypothesis==6.21.1
 matplotlib==3.5.1
 multihist==0.6.5
 nestpy==1.5.0; python_version<="3.9"
-git+https://github.com/NESTCollaboration/nestpy.git; python_version=="3.10"
+git+https://github.com/NESTCollaboration/nestpy.git@v1.0.6; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -17,7 +17,7 @@ hypothesis==6.21.1
 matplotlib==3.5.1
 multihist==0.6.5
 nestpy==1.5.0; python_version<="3.9"
-git+https://github.com/NESTCollaboration/nestpy/tree/v1.5.0; python_version=="3.10"
+git+https://github.com/NESTCollaboration/nestpy/.git@v1.5.0; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -17,7 +17,7 @@ hypothesis==6.21.1
 matplotlib==3.5.1
 multihist==0.6.5
 nestpy==1.5.0; python_version<="3.9"
-git+https://github.com/NESTCollaboration/nestpy.git; python_version=="3.10"
+git+https://github.com/NESTCollaboration/nestpy/tree/v1.5.0; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5


### PR DESCRIPTION
[Issues ](https://github.com/XENONnT/pema/runs/5157424415?check_suite_focus=true)with nestpy 1.5.1, try using https://github.com/NESTCollaboration/nestpy/tree/v1.5.0 instead

Related:
 - https://github.com/NESTCollaboration/nestpy/pull/80
 - https://github.com/NESTCollaboration/nestpy/issues/83