### PR TITLE
remote dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     assignees:
-      - jorana
+      - JoranAngevaare
   # Maintain the requirements requirements folder
   - package-ecosystem: "pip"
     directory: "/extra_requirements"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 15
     assignees:
-      - jorana
+      - JoranAngevaare

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,7 +51,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install requirements for tests and latest strax
         run: |
-          pip install git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0
           pip install -r extra_requirements/requirements-tests.txt
           python setup.py develop
       # Secrets and required files

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -2,37 +2,4 @@
 strax==1.1.7
 straxen==1.4.0
 wfsim==0.5.13
-
-# File for the requirements of pema with the automated tests
-blosc==1.10.4                                   # Strax dependency
-boltons==21.0.0
-datashader==0.13.0
-dill==0.3.4                                     # Strax dependency
-coveralls==3.3.1
-commentjson==0.9.0
-coverage==6.3.2
-dask==2022.2.1
-flake8==4.0.1
-hypothesis==6.21.1
-matplotlib==3.5.1
-multihist==0.6.5
-# nestpy==1.5.1; python_version<="3.9"
-# git+https://github.com/NESTCollaboration/nestpy.git; python_version=="3.10"
-npshmex==0.2.1                                  # Strax dependency
-numba==0.55.1                                   # Strax dependency
-numpy==1.21.5
-nestpy==1.5.0
-pandas==1.4.1                                   # Strax dependency
-psutil==5.9.0                                   # Strax dependency
-pytest==7.0.1
-pytest-cov==3.0.0
-pymongo==3.12.0                                 # Strax dependency
-scikit-learn==1.0.2
-scipy==1.8.0                                    # Strax dependency
-tensorflow==2.8.0
-tqdm==4.63.0
-xarray==0.21.1
-utilix==0.6.6
-uproot==4.2.0
-zstd==1.5.1.0                                   # Strax dependency
-
+git+https://github.com/XENONnT/ax_env


### PR DESCRIPTION
Run dependabot in a dedicated [repo](https://github.com/XENONnT/ax_env) to avoid tracking all dependencies for strax(en) etc several times

_PR family_:
- https://github.com/AxFoundation/strax/pull/683
- https://github.com/XENONnT/straxen/pull/1008
- https://github.com/XENONnT/pema/pull/204
- https://github.com/XENONnT/WFSim/pull/358
- https://github.com/XENONnT/reprox/pull/54