### PR TITLE
Add test for event matching customization

### DIFF
--- a/pema/match_plugins.py
+++ b/pema/match_plugins.py
@@ -293,7 +293,7 @@ class TruthId(PeakId):
 
 def fill_start_end(truth, truth_event, end_field='endtime'):
     """Set the 'time' and 'endtime' fields based on the truth"""
-    truth_number = truth_event['truth_number']
+    truth_number = truth['event_number']
     starts = truth['time']
     stops = truth[end_field]
     _fill_start_end(truth_number, stops, starts, truth_event)
@@ -301,7 +301,7 @@ def fill_start_end(truth, truth_event, end_field='endtime'):
 
 @numba.njit()
 def _fill_start_end(truth_number, stops, starts, truth_event):
-    for i, ev_i in enumerate(truth_number):
+    for i, ev_i in enumerate(truth_event['truth_number']):
         mask = truth_number == ev_i
         start = starts[mask].min()
         stop = stops[mask].max()

--- a/pema/match_plugins.py
+++ b/pema/match_plugins.py
@@ -221,7 +221,7 @@ class MatchEvents(strax.OverlapWindowPlugin):
         unique_numbers = np.unique(truth['event_number'])
         res = np.zeros(len(unique_numbers), self.dtype)
         res['truth_number'] = unique_numbers
-        fill_start_end(truth, res)
+        fill_start_end(truth, res, self.use_endtime_field)
         if self.check_event_endtime:
             assert np.all(res['endtime'] > res['time'])
         assert np.all(np.diff(res['time']) > 0)

--- a/pema/match_plugins.py
+++ b/pema/match_plugins.py
@@ -217,7 +217,7 @@ class MatchEvents(strax.OverlapWindowPlugin):
     ]
 
     def compute(self, truth, events):
-        unique_numbers = np.unique(truth['event_number'])
+        unique_numbers = np.unique(truth[self.sim_id_field])
         res = np.zeros(len(unique_numbers), self.dtype)
         res['truth_number'] = unique_numbers
         fill_start_end(truth, res)

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -229,6 +229,14 @@ class TestStack(unittest.TestCase):
         st.plot_peaks(run_id, time_within=peaks[0], xaxis=False)
         pema.save_canvas('test_fig', os.path.join(self.tempdir, 'figs'), tight_layout=True)
 
+    def test_later_alternative_configs(self):
+        st = self.script.st
+        st.set_config(check_event_endtime=False)
+        st.make(run_id, 'truth_events')
+
+        st.set_config(use_endtime_field='endtime')
+        st.make(run_id, 'truth_events')
+
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.tempdir)

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -234,8 +234,8 @@ class TestStack(unittest.TestCase):
         st.set_config(dict(check_event_endtime=False))
         st.make(run_id, 'truth_events')
 
-        st.set_config(dict(sim_id_field='g4id'))
-        st.make(run_id, 'truth_events')
+#        st.set_config(dict(sim_id_field='g4id'))
+#        st.make(run_id, 'truth_events')
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -234,7 +234,7 @@ class TestStack(unittest.TestCase):
         st.set_config(dict(check_event_endtime=False))
         st.make(run_id, 'truth_events')
 
-        st.set_config(dict(use_endtime_field='endtime'))
+        st.set_config(dict(sim_id_field='g4id'))
         st.make(run_id, 'truth_events')
 
     @classmethod

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -231,10 +231,10 @@ class TestStack(unittest.TestCase):
 
     def test_later_alternative_configs(self):
         st = self.script.st
-        st.set_config(check_event_endtime=False)
+        st.set_config(dict(check_event_endtime=False))
         st.make(run_id, 'truth_events')
 
-        st.set_config(use_endtime_field='endtime')
+        st.set_config(dict(use_endtime_field='endtime'))
         st.make(run_id, 'truth_events')
 
     @classmethod


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
This PR adds two options:
 - use a different field from the truth info to base the endtime on
 - allows bypassing the strict > 0 ns duration of events in simulation

For the latter, I had to change one utility function slightly, since numba does not support flexible field indexing.

Both options should allow using this plugin despite the issues mentioned in:
https://github.com/XENONnT/WFSim/issues/394