### PR TITLE
Trying to fix `touching_windows` bug

### DIFF
--- a/pema/matching.py
+++ b/pema/matching.py
@@ -76,7 +76,8 @@ def match_peaks(allpeaks1,
     )
 
     log.debug('Getting windows')
-    windows = strax.touching_windows(allpeaks1, allpeaks2, window=matching_fuzz)
+    windows = strax.processing.general._touching_windows(allpeaks1['time'], strax.endtime(allpeaks1), allpeaks2['time'], 
+                                                         strax.endtime(allpeaks2), window=matching_fuzz)
     deep_windows = np.empty((0, 2), dtype=(np.int64, np.int64))
     # Each of the windows projects to a set of peaks in allpeaks2
     # belonging to allpeaks1. We also need to go the reverse way, which

--- a/pema/matching.py
+++ b/pema/matching.py
@@ -76,6 +76,8 @@ def match_peaks(allpeaks1,
     )
 
     log.debug('Getting windows')
+    
+    # FIXME: This is a hack to get around the fact that we trigger bug in _check_objects_non_negative_length for truth
     windows = strax.processing.general._touching_windows(allpeaks1['time'], strax.endtime(allpeaks1), allpeaks2['time'], 
                                                          strax.endtime(allpeaks2), window=matching_fuzz)
     deep_windows = np.empty((0, 2), dtype=(np.int64, np.int64))

--- a/pema/matching.py
+++ b/pema/matching.py
@@ -78,8 +78,18 @@ def match_peaks(allpeaks1,
     log.debug('Getting windows')
     
     # FIXME: This is a hack to get around the fact that we trigger bug in _check_objects_non_negative_length for truth
-    windows = strax.processing.general._touching_windows(allpeaks1['time'], strax.endtime(allpeaks1), allpeaks2['time'], 
+    # WFSim for unknown reason is generating negative length truth and it is beyond the scope
+    # of this package to fix it. So we just ignore it here and print warning.
+    if np.any(allpeaks1['endtime']<0):
+        log.warning("Negative length truth found, ignoring it and changing the event_number to -1")    
+        windows = strax.processing.general._touching_windows(allpeaks1['time'], strax.endtime(allpeaks1), allpeaks2['time'], 
                                                          strax.endtime(allpeaks2), window=matching_fuzz)
+        bad_event_numbers = allpeaks1[allpeaks1['endtime']<0]['event_number']
+        for event_number in bad_event_numbers:
+            allpeaks1[allpeaks1['event_number']==event_number]['event_number'] = -1
+    else:
+        windows = strax.touching_windows(allpeaks1, allpeaks2, window=matching_fuzz)
+
     deep_windows = np.empty((0, 2), dtype=(np.int64, np.int64))
     # Each of the windows projects to a set of peaks in allpeaks2
     # belonging to allpeaks1. We also need to go the reverse way, which


### PR DESCRIPTION
Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible

**What is the problem / what does the code in this PR do**
Currently `pema` is not usable because of a bug shown in `strax.touching_windows` [here](https://github.com/XENONnT/pema/blob/1129a7969f700ede7abd0b71e5e626379437e96e/pema/matching.py#L79). See here for the [issue](https://github.com/XENONnT/pema/issues/298). This PR tries to understand what happened and bypass the bug.

**Can you briefly describe how it works?**
It seems to be a `numba` problem that, the `_check_objects_non_negative_length` will lead to problems, even though there is no negative length at all. 

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
