### PR TITLE
Deprecate the usage of `XENONnT/ax_env`

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -2,7 +2,7 @@ strax>=1.6.0
 straxen>=2.2.0
 wfsim>=1.2.0
 epix>=0.3.6
-git+https://github.com/XENONnT/ax_env
+git+https://github.com/XENONnT/base_environment
 
 # For testing running notebooks
 nbmake


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Use base_environment for pytest, following https://github.com/XENONnT/base_environment/pull/1487.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**
